### PR TITLE
개발 환경 RDB 인스턴스 생성 close #10

### DIFF
--- a/main.develop.rdb.tf
+++ b/main.develop.rdb.tf
@@ -1,0 +1,72 @@
+resource "ncloud_access_control_group" "develop_rdb_acg" {
+  name   = "${var.zone_name}-${var.terraform_name}-${var.develop_env_name}-rdb-acg"
+  vpc_no = ncloud_vpc.develop_vpc.id
+}
+
+resource "ncloud_access_control_group_rule" "develop_rdb_acg" {
+  access_control_group_no = ncloud_access_control_group.develop_rdb_acg.id
+
+  inbound {
+    protocol                       = "TCP"
+    source_access_control_group_no = ncloud_access_control_group.develop_bastion_acg.id
+    port_range                     = "22"
+    description                    = "accept 22 port (only bastion)"
+  }
+  inbound {
+    protocol                       = "TCP"
+    source_access_control_group_no = ncloud_access_control_group.develop_was_acg.id
+    port_range                     = "3306"
+    description                    = "accept 1194 port(all ip)"
+  }
+  inbound {
+    protocol    = "UDP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "1194"
+    description = "accept 1194 port(all ip)"
+  }
+  outbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "1-65535"
+    description = "accept TCP 1-65535 port"
+  }
+  outbound {
+    protocol    = "UDP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "1-65535"
+    description = "accept UDP 1-65535 port"
+  }
+  outbound {
+    protocol    = "ICMP"
+    ip_block    = "0.0.0.0/0"
+    description = "accept ICMP"
+  }
+}
+
+resource "ncloud_network_interface" "develop_rdb_nic" {
+  name                  = "${var.terraform_name}-rdb-nic"
+  subnet_no             = ncloud_subnet.develop_data_subnet.id
+  access_control_groups = [ncloud_access_control_group.develop_rdb_acg.id]
+}
+
+resource "ncloud_server" "develop_rdb_server" {
+  subnet_no                 = ncloud_subnet.develop_data_subnet.id
+  name                      = "${var.zone_name}-${var.terraform_name}-${var.develop_env_name}-rdb"
+  server_image_product_code = "SW.VSVR.OS.LNX64.UBNTU.SVR2004.B050"
+  server_product_code       = "SVR.VSVR.STAND.C002.M008.NET.HDD.B050.G002"
+  login_key_name            = ncloud_login_key.develop_key.key_name
+  network_interface {
+    network_interface_no = ncloud_network_interface.develop_rdb_nic.id
+    order                = 0
+  }
+}
+
+data "ncloud_root_password" "develop_rdb_root_password" {
+  server_instance_no = ncloud_server.develop_rdb_server.instance_no
+  private_key        = ncloud_login_key.develop_key.private_key
+}
+
+resource "local_file" "develop_rdb_root_password_file" {
+  filename = "${ncloud_server.develop_rdb_server.name}-root-password.txt"
+  content  = "${ncloud_server.develop_rdb_server.name} => ${data.ncloud_root_password.develop_rdb_root_password.root_password}"
+}

--- a/main.develop.vpc.tf
+++ b/main.develop.vpc.tf
@@ -2,8 +2,6 @@
 resource "ncloud_vpc" "develop_vpc" {
   name            = "${var.zone_name}-${var.terraform_name}-${var.develop_env_name}-vpc"
   ipv4_cidr_block = var.vpc_develop_cidr
-
-
 }
 
 // NACL - PUBLIC

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     ncloud = {
-      source = "NaverCloudPlatform/ncloud"
-      version = "2.3.18"
+      source  = "NaverCloudPlatform/ncloud"
+      version = "2.3.19"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,15 @@ variable "production_env_name" {
 variable "vpc_develop_cidr" {
   default = "10.84.0.0/16"
 }
+
+variable "db_user_name" {
+  default = "root"
+}
+
+variable "db_password" {
+  default = "abc123"
+}
+
+variable "db_database_name" {
+  default = "gifthub"
+}


### PR DESCRIPTION
## Motivation

개발 환경에서 DB 인스턴스를 관리하기 위한 RDB 인스턴스 구현 필요

## Problem Solving

NCloud Terraform에서는 RDS와 같은 PaaS가 존재하지 않기 때문에 Server 인스턴스를 생성하여 관리하도록 함

